### PR TITLE
Update build-test.yml

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.17
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
Bump to Go 1.17 to support revised build constraints